### PR TITLE
Double line feed when adding/editing notes. Adding data structure

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -12,8 +12,6 @@
 
 using com.nobodynoze.flogger;
 using com.nobodynoze.notemanager;
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 //imports for FileStream and XmlSerializer
@@ -25,7 +23,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
-using static Jotter.MainWindow;
 
 namespace Jotter
 {

--- a/NoBuild/DataFile-Structure.xml
+++ b/NoBuild/DataFile-Structure.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ArrayOfNote xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Note>
+    <IdIndexer>c36b2648-67e2-40b5-9821-84672ea7eb8c</IdIndexer>
+    <Title>A Better, better Note!</Title>
+    <Text>This is just adding data to an existing note
+    </Text>
+    <IsDeleted>false</IsDeleted>
+  </Note>
+</ArrayOfNote>

--- a/NoteTemplateEditor.xaml
+++ b/NoteTemplateEditor.xaml
@@ -194,8 +194,17 @@
 
         <!-- Note Content -->
         <Grid x:Name="gridContainsNote" Grid.Row="1" MaxWidth="900" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-            <RichTextBox x:Name="rchEditNote" Width="{Binding ElementName=gridContainsNote}" FontSize="16" VerticalScrollBarVisibility="Visible" />
-
+            <RichTextBox x:Name="rchEditNote"
+             Width="{Binding ElementName=gridContainsNote}" 
+             FontSize="16" 
+             VerticalScrollBarVisibility="Visible" 
+             >
+                <RichTextBox.Resources>
+                    <Style TargetType="{x:Type Paragraph}">
+                        <Setter Property="Margin" Value="0" />
+                    </Style>
+                </RichTextBox.Resources>
+            </RichTextBox>
         </Grid>
 
     </Grid>

--- a/auto-build.cmd
+++ b/auto-build.cmd
@@ -7,7 +7,7 @@
     @REM https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained
 
 @REM Set IS_DEBUG=true to only build DEBUG build. FALSE = release build.
-set IS_DEBUG=true
+set IS_DEBUG=false
 set VERBOSE_LEVEL=normal
 
 set CURDIR=%CD%
@@ -34,7 +34,7 @@ if "%IS_DEBUG%" == "true" (
     dotnet build "%SOLUTIONFILE%" --framework %FRAMEWORK% --configuration %CONFIG_DEBUG% --property:Platform=%PLATFORM% --nologo -nodeReuse:true --verbosity "%VERBOSE_LEVEL%"
     dotnet publish "%SOLUTIONFILE%" --framework %FRAMEWORK% -r "%RUNTIME_IDENTIFIER%" --configuration %CONFIG_DEBUG% --property:Platform=%PLATFORM% --self-contained true --property:PublishSingleFile=true  --property:IncludeNativeLibrariesForSelfExtract=true --verbosity "%VERBOSE_LEVEL%" --property:PublishDir=%PUBLISHDIR_DEBUG%
     echo.
-    echo Product location %RUNTIME_IDENTIFIER%-%FRAMEWORK%: %PUBLISHDIR_DEBUG%
+    echo Product location [DEBUG]  %RUNTIME_IDENTIFIER%-%FRAMEWORK%: %PUBLISHDIR_DEBUG%
 
 ) else (
     echo RUNNING RELEASE BUILD...
@@ -42,7 +42,7 @@ if "%IS_DEBUG%" == "true" (
     dotnet build "%SOLUTIONFILE%" --framework %FRAMEWORK% --configuration %CONFIG_RELEASE% --property:Platform=%PLATFORM% --nologo -nodeReuse:true --verbosity "%VERBOSE_LEVEL%"
     dotnet publish "%SOLUTIONFILE%" --framework %FRAMEWORK% -r "%RUNTIME_IDENTIFIER%" --configuration %CONFIG_RELEASE% --property:Platform=%PLATFORM% --self-contained true --property:PublishSingleFile=true  --property:IncludeNativeLibrariesForSelfExtract=true --verbosity "%VERBOSE_LEVEL%" --property:PublishDir=%PUBLISHDIR_RELEASE%
     echo.
-    echo Product location %RUNTIME_IDENTIFIER%-%FRAMEWORK%: %PUBLISHDIR_RELEASE%    
+    echo Product location [RELEASE]  %RUNTIME_IDENTIFIER%-%FRAMEWORK%: %PUBLISHDIR_RELEASE%    
 )
 
 


### PR DESCRIPTION
When editing or adding notes, a double linefeed was present in the note (RichEdit control under NoteTemplateEditor).

Additions:
- Added data structure
- Changed auto-build flag from debug to release.