### PR TITLE
theme fallback fix, user log settings

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -88,8 +88,19 @@ namespace Jotter
             LoadAppSettings(settingsManager.Settings);
 
             logger.LogWritten += LogWrite_Handler;
-            logger.LogFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                                           Path.Join(Assembly.GetExecutingAssembly().GetName().Name, "JotterNotes.log"));
+            
+            //Get log path custom or not
+            if ((settingsManager.Settings.LogPath != string.Empty) || (settingsManager.Settings.LogPath != null))
+                logger.LogFile = settingsManager.Settings.LogPath;
+            else
+            {
+                logger.LogFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                                               Path.Join(Assembly.GetExecutingAssembly().GetName().Name, "JotterNotes.log"));
+                //Turn logging off if no path..
+                //logger.EnableLogger = false;
+                //TODO: Add code in log handler to check if log file is empty, then turn off logging.   
+            }
+
             logger.EnableDTStamps = true;
 
             //Dir has to be created first before any log written. Access error appears if logging first.

--- a/NoBuild/Notes.md
+++ b/NoBuild/Notes.md
@@ -313,10 +313,24 @@ file it is. In this case, the SharedResources.xaml is where it could happen.
 
 ---
 
-## 2024-01-05 -> 3:475am
+## 2025-01-05 -> 3:475am
 - Bug in versioninfo in settings. Still working on, but added logging since the compiled process could not attach for debugging
 - small autobuild output changes.
 
 ---
 
+## 2025-01-06 -> 7:20am
+- Fixing default theme fallback, removing custom theme
+- Fixing loading log settings. Saving has not been completed. 
+- Connecting auto save intervals to settings. created in settings cb_AutoSaveValChanged() * STOPPED ON NoteTemaplteEditor.cs line 53
+
+---
+
+## 2025-01-011 -> 7:20am
+- Continuing from above status. 
+- Changing year in statuses to 2025.
+- log settings are able to save and switch to new log from settings.
+- light testing on loading of settings and saving for logfile.
+
+---
 

--- a/Settings.xaml
+++ b/Settings.xaml
@@ -250,11 +250,19 @@
                 <TextBlock Grid.Row="0" Text="General Settings" Style="{StaticResource HeaderTextStyle}" Grid.ColumnSpan="2"/>
                 <StackPanel Grid.Row="1" Orientation="Horizontal" Grid.ColumnSpan="2" Margin="0,0,0,36" Grid.RowSpan="2">
                     <TextBlock Text="User data: " Style="{StaticResource GeneralTextStyle}" VerticalAlignment="Center"/>
-                    <TextBox x:Name="TextUserData" Text="C:\MyApp\SaveFile" Style="{StaticResource FilePathTextStyle}" VerticalAlignment="Center" IsReadOnly="False"/>
+                    <TextBox x:Name="TextUserData" 
+                             Text="{Binding txtUserData, Mode=TwoWay, UpdateSourceTrigger=LostFocus, TargetNullValue=C:\MyApp\SaveFile}" 
+                             Style="{StaticResource FilePathTextStyle}" 
+                             VerticalAlignment="Center" 
+                             IsReadOnly="False"/>
                 </StackPanel>
+
                 <StackPanel Grid.Row="2" Orientation="Horizontal" Grid.ColumnSpan="2" Margin="0,0,0,11" Grid.RowSpan="2">
                     <TextBlock Text="Log path:  " Style="{StaticResource GeneralTextStyle}" VerticalAlignment="Center"/>
-                    <TextBox x:Name="TextLogFile" Text="C:\Logs\logfile.txt" Style="{StaticResource FilePathTextStyle}" VerticalAlignment="Center"/>
+                    <TextBox x:Name="TextLogFile" 
+                             Text="{Binding txtLogFile, Mode=TwoWay, UpdateSourceTrigger=LostFocus, TargetNullValue=C:\Logs\logfile.txt}" 
+                             Style="{StaticResource FilePathTextStyle}" 
+                             VerticalAlignment="Center"/>
                 </StackPanel>
 
 
@@ -294,18 +302,20 @@
                         <ComboBoxItem>Light Theme</ComboBoxItem>
                         <ComboBoxItem>Dark Theme</ComboBoxItem>
                         <ComboBoxItem>Default Theme</ComboBoxItem>
-                        <ComboBoxItem>Custom Theme</ComboBoxItem>
+                        <!--<ComboBoxItem>Custom Theme</ComboBoxItem>-->
                     </ComboBox>
                 </StackPanel>
 
-                <!-- Set number of seconds for auto save -->
+                <!-- Set number of seconds for auto save 
+                Adding a Tag property to each cb item stores the value we select:
+                -->
                 <StackPanel Grid.Row="9" Orientation="Horizontal" Grid.ColumnSpan="2" Margin="0,0,0,11" Grid.RowSpan="2">
                     <TextBlock Text="Set number of seconds for auto save: " VerticalAlignment="Center" Margin="5,5,0,5"/>
-                    <ComboBox SelectedIndex="0" Margin="5,5,0,5" Height="25" IsEnabled="False">
-                        <ComboBoxItem>Auto [3 seconds]</ComboBoxItem>
-                        <ComboBoxItem>25 seconds</ComboBoxItem>
-                        <ComboBoxItem>45 seconds</ComboBoxItem>
-                        <ComboBoxItem>60 seconds</ComboBoxItem>
+                    <ComboBox x:Name="AutoSave" SelectedIndex="0" Margin="5,5,0,5" Height="25" IsEnabled="True" SelectionChanged="cb_AutoSaveValChanged">
+                        <ComboBoxItem Tag="3">Auto [3 seconds]</ComboBoxItem>
+                        <ComboBoxItem Tag="25">25 seconds</ComboBoxItem>
+                        <ComboBoxItem Tag="45">45 seconds</ComboBoxItem>
+                        <ComboBoxItem Tag="60">60 seconds</ComboBoxItem>
                     </ComboBox>
                 </StackPanel>
 


### PR DESCRIPTION
theme fallback fix - if theme is invalid or previous selected and doesn't exist, fallback to default theme.

added settings for user to change log file, load log file settings.

In the changes, there's a TODO to turn on/off logging. More likely take flogger and port it over, enhancing it.